### PR TITLE
Create s2_install_erlang20.3.sh

### DIFF
--- a/s2_install_erlang20.3.sh
+++ b/s2_install_erlang20.3.sh
@@ -5,3 +5,5 @@ rm -rf 20.3.tar.gz
 mv 20.3 ~/.kerl/installs/
 echo "20.3,20.3" >> ~/.kerl/otp_builds 
 echo "20.3 /home/semaphore/.kerl/installs/20.3" >> ~/.kerl/otp_installations 
+#activate version 20 in elixir env
+sed -i 's/21/20/g' ~/.kiex/elixirs/elixir-1.7.3.env 


### PR DESCRIPTION
Script should be run on semaphore2: bash s2_install_erlang20.3.sh
Downloads a prebuilt  erlang 20.3, unpacks  and puts in the right place
After running the script the new version should be activated by : . /home/semaphore/.kerl/installs/20.3/activate