### PR TITLE
Use older POSIX arithmetic expansion, for portability

### DIFF
--- a/aws-sec-group-from-ip-list.sh
+++ b/aws-sec-group-from-ip-list.sh
@@ -32,7 +32,7 @@ aws_sec_group="semaphore-worker-security-group-"
 aws_sec_group_limit=50
 
 ips_count=$(cat $ip_list | wc -l)
-let sec_groups_needed=($ips_count+$aws_sec_group_limit-1)/$aws_sec_group_limit;
+let sec_groups_needed=$(($ips_count+$aws_sec_group_limit-1))/$aws_sec_group_limit;
 
 start_line=1
 finish_line=$aws_sec_group_limit


### PR DESCRIPTION
I found a small portability bug in the script [aws-sec-group-from-ip-list.sh](https://github.com/renderedtext/semaphore-scripts/blob/3c1e04f09d1a48ab30678d822db5cd0903167800/aws-sec-group-from-ip-list.sh#L35): 

```
$ bash aws-sec-group-from-ip-list.sh [OUR_VPC]
aws-sec-group-from-ip-list.sh: line 35: let: sec_groups_needed=(: syntax error: operand expected (error token is "(")
```

This corresponds to this line, which is using a newer form of arithmetic expansion:

```let sec_groups_needed=($ips_count+$aws_sec_group_limit-1)/$aws_sec_group_limit;```

I made it work for me by changing it to use the older `$(())` syntax for expansion, for portability:

```let sec_groups_needed=$(($ips_count+$aws_sec_group_limit-1))/$aws_sec_group_limit;```

And then the script ran successfully.

I ran the script from my MacOS Mojave (10.14.2) workstation and using the following bash versions:

- 3.2.57(1)-release(x86_64-apple-darwin18)
- 5.0.2(1)-release (x86_64-apple-darwin18.2.0) 

Hope that helps.