### PR TITLE
Allow Bundler version to be specified

### DIFF
--- a/semaphore-ruby-setup.sh
+++ b/semaphore-ruby-setup.sh
@@ -21,6 +21,7 @@ set -e
 
 ruby_version=${1:-"2.5.3"}
 gem_version=${2:-"2.7.7"}
+bundler_version=${3:-"1.17.3"}
 ruby_archive="$ruby_version.tar.gz"
 ruby_install_path="/home/runner/.rbenv/versions/$ruby_version"
 semaphore_test_boosters="no"
@@ -74,8 +75,8 @@ ruby --version
 
 if [ ! -e $HOME/.rbenv/versions/$ruby_version/bin/bundle ]
 then
-  echo "Installing bundler..."
-  gem install bundler --no-document
+  echo "Installing bundler $bundler_version..."
+  gem install bundler --version $bundler_version --no-document
 fi
 
 if ! [ $gem_version = "$(gem --version)" ]; then


### PR DESCRIPTION
The script used to install the latest version of the Bundler which is currently 2.0.1. For apps that rely on Bundler 1 the attempt to install gems would fail, so it makes sense to make the version optional.